### PR TITLE
Update maintainer info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,4 @@
 Rafael Martinez Guerrero - PostgreSQL-es
-
 rafael@postgresql.org.es
 http://www.postgresql.org.es/
 https://github.com/rafaelma/pgbackman

--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,3 @@
 Check the PgBackMan documentation:
-http://www.pgbackman.org/documentation.html
-
+English: https://github.com/jvaskonen/pgbackman/blob/main/docs/manual.rst
+Español: https://github.com/jvaskonen/pgbackman/blob/main/docs/manual_es.rst

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PgBackMan
 =========
 
-PostgreSQL backup manager / http://www.pgbackman.org/
+PostgreSQL backup manager / https://github.com/jvaskonen/pgbackman
 
 PgBackMan is a tool for managing PostgreSQL logical backups created
 with ``pg_dump`` and ``pg_dumpall``.

--- a/bin/pgbackman
+++ b/bin/pgbackman
@@ -5,8 +5,10 @@
 #
 # Copyright (c) 2015 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of Pgbackman
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman-bulk-update
+++ b/bin/pgbackman-bulk-update
@@ -5,8 +5,10 @@
 #
 # Copyright (c) 2015 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of Pgbackman
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_alerts
+++ b/bin/pgbackman_alerts
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2015 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014-2015 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_control
+++ b/bin/pgbackman_control
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_dump
+++ b/bin/pgbackman_dump
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_maintenance
+++ b/bin/pgbackman_maintenance
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_restore
+++ b/bin/pgbackman_restore
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackman
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/pgbackman_status_info
+++ b/bin/pgbackman_status_info
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2015 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014-2015 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by 

--- a/bin/pgbackman_zabbix_autodiscovery
+++ b/bin/pgbackman_zabbix_autodiscovery
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2015 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014-2015 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by 

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,12 @@
 Source: pgbackman
 Section: database
 Priority: optional
-Maintainer: Rafael Martinez Guerrero <rafael@e-mc2.net>
+Maintainer: James Miller <jvaskonen@toastaddict.org>
 Build-Depends: debhelper (>= 9~)
  , python | python-all | python-dev | python-all-dev
  , python-setuptools
 Standards-Version: 3.9.8
-Homepage: http://www.pgbackman.org/
+Homepage: https://github.com/jvaskonen/pgbackman
 Vcs-Browser: https://github.com/jvaskonen/pgbackman
 Vcs-Git: git://github.com/jvaskonen/pgbackman.git
 X-Python-Version: >= 2.6

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -5,10 +5,10 @@ PgBackMan - PostgreSQL Backup Manager
 |
 | Version-1.3.1
 |
-| Author: Rafael Martinez Guerrero (University of Oslo)
-| E-mail: rafael@postgresql.org.es
+| Original Author: Rafael Martinez Guerrero (University of Oslo)
+| Author: James Miller
+| E-mail: jvaskonen@toastaddict.org
 | Source: https://github.com/jvaskonen/pgbackman
-| Web: http://www.pgbackman.org/
 |
 
 .. contents::
@@ -191,7 +191,7 @@ version from the master branch at the GitHub repository.
 ::
 
  [root@server]# cd
- [root@server]# git clone https://github.com/rafaelma/pgbackman.git
+ [root@server]# git clone https://github.com/jvaskonen/pgbackman.git
 
  [root@server]# cd pgbackman
  [root@server]# ./setup2.py install --install-scripts=/usr/bin
@@ -199,34 +199,6 @@ version from the master branch at the GitHub repository.
 
 This will install all users, groups, programs, configuration files, logfiles and the
 pgbackman module in your system.
-
-
-Installing via RPM packages
----------------------------
-
-RPM packages for CentOS 6/7 and RHEL6/7 are available at
-http://www.pgbackman.org/download.html
-
-Install the RPM package with::
-
-  [root@server]# rpm -Uvh pgbackman-<version>.rpm
-
-We are working to get RPM packages for PgBackMan in the official
-PostgreSQL Yum repository.
-
-
-Installing via Deb packages
-----------------------------
-
-Deb packages for Debian7 are available at
-http://www.pgbackman.org/download.html
-
-Install the Deb package with::
-
-  [root@server]# dpkg -i pgbackman_<version>.deb
-
-We are working to get DEB packages for PgBackMan in the official
-PostgreSQL apt repository.
 
 
 Installing the pgbackman Database
@@ -3132,7 +3104,7 @@ production at the University of Oslo. However, as any software,
 PgBackMan is not bug free.
 
 If you discover a bug, please file a bug through the GitHub Issue page
-for the project at: https://github.com/rafaelma/pgbackman/issues
+for the project at: https://github.com/jvaskonen/pgbackman/issues
 
 
 Authors
@@ -3145,15 +3117,17 @@ In alphabetical order:
 | E-mail: rafael@postgresql.org.es / rafael@usit.uio.no
 | PostgreSQL-es / University Center for Information Technology (USIT), University of Oslo, Norway
 |
+| James Miller
+| E-mail: jvaskonen@toastadict.org
 
 License and Contributions
 =========================
 
-PgBackMan is the property of Rafael Martinez Guerrero / PostgreSQL-es
-and USIT-University of Oslo, and its code is distributed under GNU
-General Public License 3.
+PgBackMan is the property of Rafael Martinez Guerrero / PostgreSQL-es,
+James Miller and USIT-University of Oslo, and its code is distributed
+under GNU General Public License 3.
 
 | Copyright © 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
 | Copyright © 2014 USIT-University of Oslo.
+| Copyright © 2023 James Miller
 
-Repackaged with minor modifications by James Miller in 2023

--- a/docs/manual_es.rst
+++ b/docs/manual_es.rst
@@ -5,10 +5,10 @@ PgBackMan - Administrador de copias de seguridad
 |
 | Versión-1.3.1
 |
-| Autor: Rafael Martinez Guerrero (Universidad de Oslo)
-| Correo electrónico: rafael@postgresql.org.es
+| Autor Original: Rafael Martinez Guerrero (Universidad de Oslo)
+| Autor: James Miller
+| Correo electrónico: jvaskonen@toastaddict.org
 | Código fuente: https://github.com/jvaskonen/pgbackman
-| Web: http://www.pgbackman.org/
 |
 
 .. contents::
@@ -210,7 +210,7 @@ GitHub.
 ::
 
  [root@server]# cd
- [root@server]# git clone https://github.com/rafaelma/pgbackman.git
+ [root@server]# git clone https://github.com/jvaskonen/pgbackman.git
 
  [root@server]# cd pgbackman
  [root@server]# ./setup2.py install --install-scripts=/usr/bin
@@ -218,34 +218,6 @@ GitHub.
 
 Esto instalará todos los usuarios, grupos, programas, archivos de
 configuración y el módulo de python pgbackman en tu sistema.
-
-
-Instalando desde paquetes RPM
------------------------------
-
-Paquetes RPM para CentOS 6/7 y RHEL6/7 están disponibles en:
-http://www.pgbackman.org/download.html
-
-Instalar el paquete RPM con::
-
-  [root@server]# rpm -Uvh pgbackman-<version>.rpm
-
-Nota: Estamos trabajando para incluir los paquetes RPM de PgBackMan en
-el repositorio oficial de PostgreSQL.
-
-
-Instalando desde paquetes Deb
------------------------------
-
-Paquetes Deb para Debian7 están disponibles en:
-http://www.pgbackman.org/download.html
-
-Instalar el paquete Deb con::
-
-  [root@server]# dpkg -i pgbackman_<version>.deb
-
-Nota: Estamos trabajando para incluir los paquetes DEB de PgBackMan en
-el repositorio oficial de PostgreSQL.
 
 
 Instalando la base de datos pgbackman
@@ -3295,7 +3267,7 @@ software, PgBackMan no está libre de errores.
 
 Si descubre algún error, mande por favor un informe a través de la
 página de GitHub disponible para este propósito:
-https://github.com/rafaelma/pgbackman/issues
+https://github.com/jvaskonen/pgbackman/issues
 
 
 Autores
@@ -3308,14 +3280,17 @@ En orden alfabético:
 | E-mail: rafael@postgresql.org.es / rafael@usit.uio.no
 | PostgreSQL-es / University Center for Information Technology (USIT), University of Oslo, Norway
 |
+| James Miller
+| E-mail: jvaskonen@toastaddict.org
 
 
 Licencia y contribuciones
 =========================
 
-PgBackMan es propiedad de Rafael Martinez Guerrero / PostgreSQL-es y
-USIT-Universidad de Oslo, y el código fuente es distribuido bajo la
-licencia GNU General Public License 3.
+PgBackMan es propiedad de Rafael Martinez Guerrero / PostgreSQL-es,
+James Miller y USIT-Universidad de Oslo, y el código fuente es distribuido
+bajo la icencia GNU General Public License 3.
 
 | Copyright © 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
 | Copyright © 2014 USIT-University of Oslo.
+| Copyright © 2023 James Miller

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -54,18 +54,17 @@ New features
   via the PgBackMan shell.
 
 
-Migration to 1.1.0
-------------------
+Migration
+---------
 
-It is very important to check the upgrade procedure to version 1.1.0
-in the documentation to avoid problems and errors when and after
-upgrading to the new version.
+It is very important to check the upgrade procedure to version in the
+documentation to avoid problems and errors when and after upgrading to
+the new version.
 
 Check the documentation: 
 
-* **[All versions]:** http://www.pgbackman.org/docs/
-* **[English]:** http://www.pgbackman.org/docs/pgbackman-manual-1.1.0.html
-* **[Español]:** http://www.pgbackman.org/docs/pgbackman-manual-1.1.0_es.html
+* **[English]:** https://github.com/jvaskonen/pgbackman/blob/main/docs/manual.rst
+* **[Español]:** https://github.com/jvaskonen/pgbackman/blob/main/docs/manual_es.rst
 
 
 Bugfixes

--- a/etc/pgbackman.conf
+++ b/etc/pgbackman.conf
@@ -1,11 +1,12 @@
 ;
 ; Copyright (c) 2013-2015 Rafael Martinez Guerrero / PostgreSQL-es
-; rafael@postgresql.org.es / http://www.postgresql.org.es/
 ;
 ; Copyright (c) 2014-2015 USIT-University of Oslo
 ;
+; Copyright (c) 2023 James Miller
+;
 ; This file is part of PgBackMan
-; https://github.com/rafaelma/pgbackman
+; https://github.com/jvaskonen/pgbackman
 ;
 ; PgBackMan is free software: you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by

--- a/etc/pgbackman_init_debian.sh
+++ b/etc/pgbackman_init_debian.sh
@@ -8,8 +8,8 @@
 # Short-Description: PostgreSQL Backup Manager
 ### END INIT INFO
 
-# Author: Rafael Martinez Guerrero <rafael@postgresql.org.es>
-# Homepage: http://www.pgbackman.org/
+# Author: James Miller <jvaskonen@toastaddict.org>
+# Homepage: https://github.com/jvaskonen/pgbackman
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC=pgbackman                    # Introduce a short description here

--- a/pgbackman/cli.py
+++ b/pgbackman/cli.py
@@ -5,8 +5,10 @@
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -6330,7 +6332,7 @@ class PgbackmanCli(cmd.Cmd):
 
         print '''
         The latest information and versions of PgBackMan can be obtained
-        from: http://www.pgbackman.org/
+        from: https://github.com/jvaskonen/pgbackman
 
         Mailing list
         ------------
@@ -6346,7 +6348,7 @@ class PgbackmanCli(cmd.Cmd):
         -----------------------------
         If you find a bug or have a feature request, file them on
         GitHub / pgbackman:
-        https://github.com/rafaelma/pgbackman/issues
+        https://github.com/jvaskonen/pgbackman/issues
 
         IRC channel
         -----------

--- a/pgbackman/config.py
+++ b/pgbackman/config.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pgbackman/database.py
+++ b/pgbackman/database.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pgbackman/logs.py
+++ b/pgbackman/logs.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
 # Copyright (c) 2014 USIT-University of Oslo
 #
+# Copyright (c) 2023 James Miller
+#
 # This file is part of PgBackMan
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # PgBackMan is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/rpm/pgbackman.spec
+++ b/rpm/pgbackman.spec
@@ -1,7 +1,7 @@
 #
 # File: pgbackman.spec
 #
-# Autor: Rafael Martinez <rafael@postgreslq.org.es>
+# Autor: James Miller <jvaskonen@toastaddict.org>
 #  
 
 %define majorversion 1.3
@@ -18,7 +18,7 @@ Version:        %{majorversion}.%{minorversion}
 Release:        1%{?dist}
 License:        GPLv3
 Group:          Applications/Databases
-Url:            http://www.pgbackman.org/
+Url:            https://github.com/jvaskonen/pgbackman
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-buildroot-%(%{__id_u} -n)
 BuildArch:      noarch

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
-# Copyright (c) 2014 USIT-University of Oslo 
+# Copyright (c) 2014 USIT-University of Oslo
+#
+# Copyright (c) 2023 James Miller
 #
 # This file is part of Pgbackman
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # Pgbackman is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -78,9 +79,9 @@ try:
     setup(name='pgbackman',
           version=pgbackman['__version__'].split(':')[1],
           description='PGBACKMAN - PostgreSQL Backup Manager',
-          author='Rafael Martinez Guerrero',
-          author_email='rafael@postgresql.org.es',
-          url='http://www.pgbackman.org/',
+          author='James Miller',
+          author_email='jvaskonen@toastaddict.org',
+          url='https://github.com/jvaskonen/pgbackman',
           packages=['pgbackman',],
           scripts=['bin/pgbackman','bin/pgbackman_control','bin/pgbackman_maintenance','bin/pgbackman_dump','bin/pgbackman_restore','bin/pgbackman_zabbix_autodiscovery','bin/pgbackman_status_info','bin/pgbackman_alerts','bin/pgbackman-bulk-update'],
           data_files=install_files,

--- a/setup2.py
+++ b/setup2.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python2
 #
 # Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
-# rafael@postgresql.org.es / http://www.postgresql.org.es/
 #
-# Copyright (c) 2014 USIT-University of Oslo 
+# Copyright (c) 2014 USIT-University of Oslo
+#
+# Copyright (c) 2023 James Miller
 #
 # This file is part of Pgbackman
-# https://github.com/rafaelma/pgbackman
+# https://github.com/jvaskonen/pgbackman
 #
 # Pgbackman is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -97,9 +98,9 @@ try:
     setup(name='pgbackman',
           version=pgbackman['__version__'].split(':')[1],
           description='PGBACKMAN - PostgreSQL Backup Manager',
-          author='Rafael Martinez Guerrero',
-          author_email='rafael@postgresql.org.es',
-          url='http://www.pgbackman.org/',
+          author='James Miller',
+          author_email='jvaskonen@toastaddict.org',
+          url='https://github.com/jvaskonen/pgbackman',
           packages=['pgbackman',],
           scripts=['bin/pgbackman','bin/pgbackman_control','bin/pgbackman_maintenance','bin/pgbackman_dump','bin/pgbackman_restore','bin/pgbackman_zabbix_autodiscovery','bin/pgbackman_status_info','bin/pgbackman_alerts','bin/pgbackman-bulk-update'],
           data_files=[('/etc/init.d', ['/tmp/pgbackman']),

--- a/sql/pgbackman.sql
+++ b/sql/pgbackman.sql
@@ -2,12 +2,13 @@
 -- PgBackMan database - Version 5:1_3_1
 --
 -- Copyright (c) 2013-2017 Rafael Martinez Guerrero / PostgreSQL-es
--- rafael@postgresql.org.es / http://www.postgresql.org.es/
 --
 -- Copyright (c) 2014 USIT-University of Oslo
 --
+-- Copyright (c) 2023 James Miller
+--
 -- This file is part of PgBackMan
--- https://github.com/rafaelma/pgbackman
+-- https://github.com/jvaskonen/pgbackman
 --
 
 \echo '# [Creating user: pgbackman_role_rw]\n'

--- a/sql/pgbackman_2.sql
+++ b/sql/pgbackman_2.sql
@@ -2,12 +2,13 @@
 -- PgBackMan database - Upgrade from 1:1_0_0 to 2:1_1_0
 --
 -- Copyright (c) 2013-2014 Rafael Martinez Guerrero / PostgreSQL-es
--- rafael@postgresql.org.es / http://www.postgresql.org.es/
 --
 -- Copyright (c) 2014 USIT-University of Oslo
 --
+-- Copyright (c) 2023 James Miller
+--
 -- This file is part of PgBackMan
--- https://github.com/rafaelma/pgbackman
+-- https://github.com/jvaskonen/pgbackman
 --
 
 BEGIN;

--- a/sql/pgbackman_3.sql
+++ b/sql/pgbackman_3.sql
@@ -2,12 +2,13 @@
 -- PgBackMan database - Upgrade from 2:1_1_0 to 3:1_2_0
 --
 -- Copyright (c) 2013-2015 Rafael Martinez Guerrero / PostgreSQL-es
--- rafael@postgresql.org.es / http://www.postgresql.org.es/
 --
 -- Copyright (c) 2015 USIT-University of Oslo
 --
+-- Copyright (c) 2023 James Miller
+--
 -- This file is part of PgBackMan
--- https://github.com/rafaelma/pgbackman
+-- https://github.com/jvaskonen/pgbackman
 --
 
 BEGIN;

--- a/sql/pgbackman_4.sql
+++ b/sql/pgbackman_4.sql
@@ -2,12 +2,13 @@
 -- PgBackMan database - Upgrade from 3:1_2_0 to 4:1_3_0
 --
 -- Copyright (c) 2013-2017 Rafael Martinez Guerrero / PostgreSQL-es
--- rafael@postgresql.org.es / http://www.postgresql.org.es/
 --
 -- Copyright (c) 2015 USIT-University of Oslo
 --
+-- Copyright (c) 2023 James Miller
+--
 -- This file is part of PgBackMan
--- https://github.com/rafaelma/pgbackman
+-- https://github.com/jvaskonen/pgbackman
 --
 
 BEGIN;


### PR DESCRIPTION
Upstream repository recently dropped reference to the pgbackman.org website with a note about not having time to maintain the project. I am followoing suit removing any references to that URL. I have also removed the original author's contact information from most locations to discourage people contacting him with pgbackrest related issues. Also updated github repo references to point at this fork.