### PR TITLE
show_pgsql_node_stats and update_backup_definition fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+pgbackman (1.3.2) unstable; urgency=low
+
+  * New release 1.3.2
+
+ -- James Miller <jvaskonen@gmail.com>  Tue, 07 May 2025 00:00:00 +0000
 
 pgbackman (1.3.1) unstable; urgency=low
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 # Makefile
 #
 
-VERSION="1.3.1"
+VERSION="1.3.2"
 
 all:	html man pdf
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -3,7 +3,7 @@ PgBackMan - PostgreSQL Backup Manager
 =====================================
 
 |
-| Version-1.3.1
+| Version-1.3.2
 |
 | Original Author: Rafael Martinez Guerrero (University of Oslo)
 | Author: James Miller

--- a/docs/manual_es.rst
+++ b/docs/manual_es.rst
@@ -3,7 +3,7 @@ PgBackMan - Administrador de copias de seguridad
 ================================================
 
 |
-| Versión-1.3.1
+| Versión-1.3.2
 |
 | Autor Original: Rafael Martinez Guerrero (Universidad de Oslo)
 | Autor: James Miller

--- a/pgbackman/cli.py
+++ b/pgbackman/cli.py
@@ -3441,7 +3441,7 @@ class PgbackmanCli(cmd.Cmd):
                 else:
                     pgsql_node_id = self.db.get_pgsql_node_id(node_id)
 
-                result = self.db.show_backup_server_stats(pgsql_node_id)
+                result = self.db.show_pgsql_node_stats(pgsql_node_id)
 
                 if len(result) > 0:
                     self.generate_unique_output(result,'pgsql_node_stats')
@@ -5754,7 +5754,7 @@ class PgbackmanCli(cmd.Cmd):
 
             if ack.lower() == 'yes':
                 try:
-                    self.db.update_backup_definition(def_id,minutes_cron,hours_cron,weekday_cron,month_cron,day_month_cron,retention_period,
+                    self.db.update_backup_definition(def_id,minutes_cron,hours_cron,day_month_cron,month_cron,weekday_cron,retention_period,
                                                      retention_redundancy,extra_backup_parameters,job_status.upper(),remarks)
 
                     print '[DONE] Backup definition DefID: ' + str(def_id) + ' updated.\n'

--- a/pgbackman/database.py
+++ b/pgbackman/database.py
@@ -2924,7 +2924,7 @@ class PgbackmanDB():
     # Method
     # ############################################
 
-    def update_backup_definition(self,def_id,minutes_cron,hours_cron,weekday_cron,month_cron,day_month_cron,retention_period,
+    def update_backup_definition(self,def_id,minutes_cron,hours_cron,day_month_cron,month_cron,weekday_cron,retention_period,
                                  retention_redundancy,extra_backup_parameters,job_status,remarks):
         """A function to update a backup definition"""
 
@@ -2936,9 +2936,9 @@ class PgbackmanDB():
                     self.cur.execute('SELECT update_backup_definition(%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)',(def_id,
                                                                                                           minutes_cron,
                                                                                                           hours_cron,
-                                                                                                          weekday_cron,
-                                                                                                          month_cron,
                                                                                                           day_month_cron,
+                                                                                                          month_cron,
+                                                                                                          weekday_cron,
                                                                                                           retention_period,
                                                                                                           retention_redundancy,
                                                                                                           extra_backup_parameters,

--- a/pgbackman/version.py
+++ b/pgbackman/version.py
@@ -1,2 +1,2 @@
 #!/usr/bin/env python2
-__version__ = '5:1.3.1'
+__version__ = '5:1.3.2'

--- a/rpm/pgbackman.spec
+++ b/rpm/pgbackman.spec
@@ -5,7 +5,7 @@
 #  
 
 %define majorversion 1.3
-%define minorversion 1
+%define minorversion 2
 %define pbm_owner pgbackman
 %define pbm_group pgbackman
 %define __python /usr/bin/python2
@@ -74,11 +74,14 @@ useradd -M -N -g pgbackman -r -d /var/lib/pgbackman -s /bin/bash \
         -c "PostgreSQL Backup Manager" pgbackman >/dev/null 2>&1 || :
 
 %changelog
-* Wed May 25 2023 - James Miller <jvaskonen@toastaddict.org> 1.3.1-1
+* Tue May 06 2025 - James Miller <jvaskonen@toastaddict.org> 1.3.2-1
+- New release 1.3.2
+
+* Thu May 25 2023 - James Miller <jvaskonen@toastaddict.org> 1.3.1-1
 - New release 1.3.1
 
 * Tue Jun 13 2017 - Rafael Martinez Guerrero <rafael@postgresql.org.es> 1.2.0-1
 - New release 1.0.0
 
-* Mon Jun 24 2014 - Rafael Martinez Guerrero <rafael@postgresql.org.es> 1.0.0-1
+* Tue Jun 24 2014 - Rafael Martinez Guerrero <rafael@postgresql.org.es> 1.0.0-1
 - New release 1.0.0


### PR DESCRIPTION
show_pgsql_node_stats was not calling the correct backend method
update_backup_definition had issues with the crontab ordering that resulted in broken crontab files